### PR TITLE
feat: button-driven UI, per-control daily kings, win streaks and live rating boards

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -2,11 +2,8 @@
 import { Bot } from "grammy";
 import * as dotenv from "dotenv";
 import { handleStart } from "./commands/start";
-import { handleStats } from "./commands/stats";
-import { handleScore } from "./commands/score";
-import { handleZuri as handleTop } from "./commands/top";
-import { handleStandings } from "./commands/standings";
 import { handleRegistration, isUserInRegistrationFlow } from "./utils/registration";
+import { handleMenuCallback } from "./utils/menu";
 import { BotError, GrammyError, HttpError } from "grammy";
 
 dotenv.config();
@@ -16,11 +13,10 @@ if (!token) throw new Error("BOT_TOKEN is missing");
 
 export const bot = new Bot(token);
 
+// /start is the only command: it registers new users and opens the button menu.
+// Everything else is driven by inline keyboard callbacks.
 bot.command("start", handleStart);
-bot.command("stats", handleStats);
-bot.command("score", handleScore);
-bot.command("standings", handleStandings);
-bot.command("top", handleTop);
+bot.on("callback_query:data", handleMenuCallback);
 
 // Handle text messages for username registration only in private chats
 bot.on("message:text", async (ctx) => {

--- a/commands/standings/index.ts
+++ b/commands/standings/index.ts
@@ -1,43 +1,22 @@
-import { Context } from "grammy";
 import { getAllUserScores, getRecentChampions } from "../../utils/championship";
 
-export async function handleStandings(ctx: Context) {
-  try {
-    // Parse command arguments
-    const args = ctx.message?.text?.split(' ') || [];
-    const option = args[1]?.toLowerCase();
-
-    if (option === 'recent' || option === 'champions') {
-      return await showRecentChampions(ctx);
-    }
-
-    // Default: show overall championship standings
-    return await showChampionshipStandings(ctx);
-
-  } catch (error) {
-    console.error('Error in standings command:', error);
-    await ctx.reply("🚨 Error retrieving championship standings. Please try again later.");
-  }
-}
-
-async function showChampionshipStandings(ctx: Context) {
+export async function renderStandings(): Promise<string> {
   const userScores = await getAllUserScores();
-  
+
   if (userScores.length === 0) {
-    return ctx.reply(
+    return (
       "🏆 CHAMPIONSHIP STANDINGS\n\n" +
       "No scores recorded yet! Start playing to earn championship points.\n\n" +
       "📊 How it works:\n" +
       "• Daily leaderboard resets every day\n" +
       "• Top 3 players earn points: 🥇300, 🥈200, 🥉100\n" +
       "• Need minimum 3 games to qualify\n" +
-      "• Rankings based on win rate\n\n" +
-      "Use /scores recent to see recent daily champions."
+      "• Rankings based on win rate"
     );
   }
 
   let message = "🏆 CHAMPIONSHIP STANDINGS\n\n";
-  
+
   userScores.forEach((user, index) => {
     const position = index + 1;
     const emoji = getPositionEmoji(position);
@@ -45,16 +24,15 @@ async function showChampionshipStandings(ctx: Context) {
   });
 
   message += "\n📊 Daily points: 🥇300, 🥈200, 🥉100";
-  message += "\nUse /standings recent for daily champions";
-  
-  await ctx.reply(message);
+
+  return message;
 }
 
-async function showRecentChampions(ctx: Context) {
+export async function renderRecentChampions(): Promise<string> {
   const recentChampions = await getRecentChampions(7);
-  
+
   if (recentChampions.length === 0) {
-    return ctx.reply(
+    return (
       "🏆 RECENT DAILY CHAMPIONS\n\n" +
       "No daily champions recorded yet!\n\n" +
       "Championship awards happen daily at 23:55 Tajikistan time.\n" +
@@ -63,30 +41,28 @@ async function showRecentChampions(ctx: Context) {
   }
 
   let message = "🏆 RECENT DAILY CHAMPIONS\n\n";
-  
-  recentChampions.forEach((champion, index) => {
+
+  recentChampions.forEach((champion) => {
     const date = new Date(champion.date).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric'
     });
-    
+
     message += `📅 ${date}:\n`;
     message += `🥇 ${champion.first_place} (${champion.win_rate_first.toFixed(1)}%)\n`;
-    
+
     if (champion.second_place) {
       message += `🥈 ${champion.second_place} (${champion.win_rate_second?.toFixed(1)}%)\n`;
     }
-    
+
     if (champion.third_place) {
       message += `🥉 ${champion.third_place} (${champion.win_rate_third?.toFixed(1)}%)\n`;
     }
-    
+
     message += "\n";
   });
 
-  message += "Use /standings to see overall standings";
-  
-  await ctx.reply(message);
+  return message.trimEnd();
 }
 
 function getPositionEmoji(position: number): string {

--- a/commands/start/index.ts
+++ b/commands/start/index.ts
@@ -1,6 +1,7 @@
 import { CommandContext, GrammyError } from "grammy";
 import { getUserMappings } from "../../utils/supabase";
 import { startRegistrationFlow } from "../../utils/registration";
+import { mainMenu, platformSelectKeyboard } from "../../utils/keyboards";
 
 export async function handleStart(ctx: CommandContext<any>) {
   try {
@@ -36,21 +37,17 @@ export async function handleStart(ctx: CommandContext<any>) {
           `You're registered on both platforms:\n` +
           `🎯 Telegram: @${telegramUsername}\n` +
           platformsText + "\n" +
-          `Фармонҳои дастрас / Available commands:\n` +
-          `📊 /stats - Омори шахмат / View your chess statistics\n` +
-          `🏆 /top - Рейтинг / See leaderboards\n` +
-          `🏆 /standings - Championship standings\n` +
-          `⚔️ /score @user1 @user2 - Муқоисаи бозигарон / Compare players\n\n` +
           `🏆 Daily Championship: Top 3 players earn points daily!\n` +
-          `Awards: 🥇300pts, 🥈200pts, 🥉100pts (need 3+ games)`
+          `Awards: 🥇300pts, 🥈200pts, 🥉100pts (need 3+ games)\n\n` +
+          `Менюро истифода баред / Use the menu below:`,
+          { reply_markup: mainMenu() }
         );
         return;
       }
-      
+
       // User has only one platform, offer to add the other
       const missingPlatform = existingMappings.chess ? 'Lichess' : 'Chess.com';
-      const missingPlatformNumber = existingMappings.chess ? '2' : '1';
-      
+
       await ctx.reply(
         `👋 Хуш омадед! / Welcome back!\n\n` +
         `Шумо аллакай сабт шудаед:\n` +
@@ -59,13 +56,11 @@ export async function handleStart(ctx: CommandContext<any>) {
         platformsText + "\n" +
         `➕ Оё мехоҳед ${missingPlatform}-ро низ илова кунед?\n` +
         `➕ Would you like to add ${missingPlatform} as well?\n\n` +
-        `Агар ҳа, рақами ${missingPlatformNumber}-ро интихоб кунед:\n` +
-        `If yes, select option ${missingPlatformNumber}:\n\n` +
-        `1️⃣ Chess.com\n` +
-        `2️⃣ Lichess\n\n` +
-        `Ё "не/no" барои бекор кардан / Or "no" to cancel`
+        `Интихоб кунед ё "Cancel" пахш кунед:\n` +
+        `Select a platform or press "Cancel":`,
+        { reply_markup: platformSelectKeyboard() }
       );
-      
+
       // Set user to platform selection state with existing data
       startRegistrationFlow(userId);
       return;
@@ -73,17 +68,14 @@ export async function handleStart(ctx: CommandContext<any>) {
 
     // Start registration flow for new users
     startRegistrationFlow(userId);
-    
+
     await ctx.reply(
       "👋 Хуш омадед ба Magnus Bot! / Welcome to Magnus Bot!\n\n" +
       "🎯 Биёед ҳисоби шахматии худро сабт кунем.\n" +
       "🎯 Let's register your chess account.\n\n" +
       "Кадом платформаро интихоб мекунед?\n" +
-      "Which platform would you like to choose?\n\n" +
-      "1️⃣ Chess.com\n" +
-      "2️⃣ Lichess\n\n" +
-      "Рақами интихобро ворид кунед (1 ё 2):\n" +
-      "Enter your choice number (1 or 2):"
+      "Which platform would you like to choose?",
+      { reply_markup: platformSelectKeyboard() }
     );
   } catch (err) {
     const errorContext = {

--- a/commands/stats/index.ts
+++ b/commands/stats/index.ts
@@ -1,45 +1,25 @@
-import { Context } from "grammy";
 import { getUserMappings } from "../../utils/userMap";
 import { fetchChessComStats, fetchLichessStats, formatCombinedStats } from "../../utils/chessApis";
 
-export async function handleStats(ctx: Context) {
-  // For /stats command without username, use the sender's username
-  let targetUsername = ctx.message?.text?.replace('/stats', '').trim().toLowerCase();
-  
-  if (!targetUsername) {
-    // If no username provided, try to get the sender's chess platforms
-    const telegramUsername = ctx.from?.username;
-    
-    if (telegramUsername) {
-      const userMappings = await getUserMappings(telegramUsername);
-      if (userMappings && (userMappings.chess || userMappings.lichess)) {
-        // Fetch stats from both platforms
-        const chessComStats = userMappings.chess ? await fetchChessComStats(userMappings.chess) : null;
-        const lichessStats = userMappings.lichess ? await fetchLichessStats(userMappings.lichess) : null;
-        
-        if (chessComStats || lichessStats) {
-          const message = formatCombinedStats(telegramUsername, chessComStats, lichessStats);
-          return ctx.reply(message);
-        }
-      }
-    }
-    
-    return ctx.reply("⚠️ Please provide a username or register using /start first.\nExample: /stats username");
-  }
-
-  // If username is provided, try to fetch from both platforms (assume it's the same on both)
+// Renders stats for a registered Telegram user (driven by the "My Stats" menu button)
+export async function renderStatsFor(telegramUsername: string): Promise<string> {
   try {
-    const chessComStats = await fetchChessComStats(targetUsername);
-    const lichessStats = await fetchLichessStats(targetUsername);
-    
-    if (!chessComStats && !lichessStats) {
-      return ctx.reply(`⚠️ User "${targetUsername}" not found on Chess.com or Lichess.`);
+    const userMappings = await getUserMappings(telegramUsername);
+
+    if (!userMappings || (!userMappings.chess && !userMappings.lichess)) {
+      return "⚠️ You are not registered yet. Use /start to register your chess accounts.";
     }
-    
-    const message = formatCombinedStats(targetUsername, chessComStats, lichessStats);
-    await ctx.reply(message);
+
+    const chessComStats = userMappings.chess ? await fetchChessComStats(userMappings.chess) : null;
+    const lichessStats = userMappings.lichess ? await fetchLichessStats(userMappings.lichess) : null;
+
+    if (!chessComStats && !lichessStats) {
+      return "⚠️ Could not fetch stats from Chess.com or Lichess right now. Please try again later.";
+    }
+
+    return formatCombinedStats(telegramUsername, chessComStats, lichessStats);
   } catch (err) {
     console.error(err);
-    ctx.reply("🚨 Error while fetching stats. Please try again later.");
+    return "🚨 Error while fetching stats. Please try again later.";
   }
-} 
+}

--- a/commands/top/index.ts
+++ b/commands/top/index.ts
@@ -1,213 +1,22 @@
-import { Context } from "grammy";
 import { getAllUserMappings } from "../../utils/userMap";
-import { getAllUserScores } from "../../utils/championship";
-import { PlayerStats, processChessComGames, processLichessGames } from "../../utils/gameStats";
+import { collectDetailedStats, DetailedPlayerStats, TimeControl } from "../../utils/dailyStats";
 import { getStartOfDayTajikistan, getTajikistanTime } from "../../utils/timeUtils";
 
-const COMMAND_DESCRIPTIONS = {
-    default: "Shows overall monthly leaderboard for all game types",
-    bugun: "Shows today's top players - Top 3 earn championship points!",
-    blitz: "Shows monthly leaderboard for blitz games (3-5 minutes)",
-    bullet: "Shows monthly leaderboard for bullet games (1-2 minutes)",
-    rapid: "Shows monthly leaderboard for rapid games (10+ minutes)"
+export type TopOption = 'bugun' | 'blitz' | 'bullet' | 'rapid' | 'month';
+
+const TITLES: Record<TopOption, string> = {
+    bugun: "🏆 Today's Leaderboard",
+    month: "🏆 Monthly Leaderboard",
+    blitz: "⚡ Monthly Blitz Leaderboard",
+    bullet: "🔫 Monthly Bullet Leaderboard",
+    rapid: "🏃 Monthly Rapid Leaderboard"
 };
 
-function getCommandHelp(): string {
-    return [
-        "📋 Available /top commands:",
-        "",
-        "🎮 /top - " + COMMAND_DESCRIPTIONS.default,
-        "🌅 /top bugun - " + COMMAND_DESCRIPTIONS.bugun,
-        "⚡ /top blitz - " + COMMAND_DESCRIPTIONS.blitz,
-        "🔫 /top bullet - " + COMMAND_DESCRIPTIONS.bullet,
-        "🏃 /top rapid - " + COMMAND_DESCRIPTIONS.rapid,
-        "",
-        "🏆 Championship System:",
-        "• Daily awards: 🥇300pts, 🥈200pts, 🥉100pts",
-        "• Need 3+ games to qualify for daily championship",
-        "• Points awarded daily at 23:55 Tajikistan time",
-        "",
-        "📊 Ranking System:",
-        "• Weighted Score = Win Rate × √(Games) × 100",
-        "• Rewards both skill and game volume",
-        "• Fair to all playing styles",
-        "",
-        "Use /standings to see championship standings!",
-        "Use any /top command to see the corresponding leaderboard!"
-    ].join('\n');
-}
-
-export async function handleZuri(ctx: Context) {
-    try {
-        const args = ctx.message?.text?.split(' ') || [];
-        const option = args[1]?.toLowerCase() || 'bugun';
-
-        if (option === 'help') {
-            return ctx.reply(getCommandHelp());
-        }
-
-        // Get user mappings from Supabase
-        const userMap = await getAllUserMappings();
-        
-        if (Object.keys(userMap).length === 0) {
-            return ctx.reply("⚠️ No registered users found. Users can register with /start");
-        }
-
-        // Initialize stats for all players
-        const playerStats = new Map<string, PlayerStats>();
-        for (const [tgUsername] of Object.entries(userMap)) {
-            playerStats.set(tgUsername, {
-                username: tgUsername,
-                wins: 0,
-                losses: 0,
-                totalGames: 0,
-                winRate: 0,
-                weightedScore: 0,
-                chesscomGames: 0,
-                lichessGames: 0
-            });
-        }
-
-        const now = new Date();
-        console.log('[Debug] Server time (UTC):', now.toISOString());
-        let startDate: Date;
-        let title: string;
-        let description: string;
-
-        if (option === 'bugun') {
-            startDate = getStartOfDayTajikistan(now);
-            const tajikNow = getTajikistanTime(now);
-
-            console.log('[Debug] Timezone info:', {
-                serverTime: now.toISOString(),
-                tajikistanTime: tajikNow.toISOString(),
-                startDate: startDate.toISOString(),
-                filterCutoff: startDate.toUTCString()
-            });
-            title = "🏆 Today's Leaderboard";
-            description = COMMAND_DESCRIPTIONS.bugun;
-        } else {
-            // Get start of month in Tajikistan time
-            const tajikTime = getTajikistanTime(now);
-            startDate = new Date(Date.UTC(
-                tajikTime.getFullYear(),
-                tajikTime.getMonth(),
-                1,
-                -5, // 00:00 Tajikistan time in UTC
-                0,
-                0,
-                0
-            ));
-            title = "🏆 Monthly Leaderboard";
-            description = option ? COMMAND_DESCRIPTIONS[option as keyof typeof COMMAND_DESCRIPTIONS] : COMMAND_DESCRIPTIONS.default;
-        }
-
-        // Track game counts by platform
-        const gameCounts = { chesscom: 0, lichess: 0 };
-
-        // Process games for each player using shared utilities
-        await Promise.all(Object.entries(userMap).map(async ([tgUsername, userMappings]) => {
-            try {
-                console.log(`[Debug] Processing ${tgUsername} - Chess.com: ${userMappings.chess || 'none'}, Lichess: ${userMappings.lichess || 'none'}`);
-                
-                // Process Chess.com games if user has Chess.com account
-                if (userMappings.chess) {
-                    const chesscomCount = await processChessComGames(
-                        userMappings.chess,
-                        tgUsername,
-                        startDate,
-                        now,
-                        playerStats,
-                        option
-                    );
-                    gameCounts.chesscom += chesscomCount;
-                }
-                
-                // Process Lichess games if user has Lichess account
-                if (userMappings.lichess) {
-                    const lichessCount = await processLichessGames(
-                        userMappings.lichess,
-                        tgUsername,
-                        startDate,
-                        now,
-                        playerStats,
-                        option
-                    );
-                    gameCounts.lichess += lichessCount;
-                }
-            } catch (error) {
-                console.error(`Error processing games for ${tgUsername}:`, error);
-            }
-        }));
-
-        // Sort players by weighted score
-        const sortedPlayers = [...playerStats.values()]
-            .sort((a, b) => {
-                if (b.weightedScore !== a.weightedScore) {
-                    return b.weightedScore - a.weightedScore;
-                }
-                if (b.winRate !== a.winRate) {
-                    return b.winRate - a.winRate;
-                }
-                return b.wins - a.wins;
-            })
-            .filter(player => player.totalGames >= 3);
-
-        if (sortedPlayers.length === 0) {
-            const timeFrame = option === 'bugun' ? 'today' : 'this month';
-            const gameType = ['blitz', 'bullet', 'rapid'].includes(option || '') ? ` for ${option} games` : '';
-            const minGamesMsg = "Players need at least 3 games to appear on the leaderboard.";
-            return ctx.reply(`📊 No qualifying players found${gameType} ${timeFrame}.\n${minGamesMsg}\n\nType /top help to see all available commands.`);
-        }
-
-        // Format response
-        const playerLines: string[] = [];
-        const userScores = await getAllUserScores();
-        const scoresMap = new Map(userScores.map(score => [score.telegram_username, score.total_score]));
-        
-        let currentRank = 1;
-        
-        for (let i = 0; i < sortedPlayers.length; i++) {
-            const player = sortedPlayers[i];
-            
-            if (i > 0) {
-                const prevPlayer = sortedPlayers[i - 1];
-                const isTied = Math.abs(player.weightedScore - prevPlayer.weightedScore) < 0.01;
-                
-                if (!isTied) {
-                    currentRank++;
-                }
-            }
-            
-            const championshipScore = scoresMap.get(player.username) || 0;
-            
-            playerLines.push(
-                `${getPositionEmoji(currentRank)} ${player.username}: ${player.weightedScore.toFixed(1)}`
-            );
-        }
-
-        let response = [
-            title,
-            description,
-            ""
-        ];
-        
-        response.push(...playerLines);
-        response.push("");
-        
-        if (option === 'bugun') {
-            response.push("Use /standings to see championship standings");
-        }
-        
-        response.push("Type /top help to see all available commands.");
-
-        await ctx.reply(response.join('\n'));
-
-    } catch (err) {
-        console.error(err);
-        ctx.reply("🚨 Error generating leaderboard. Type /top help to see available commands.");
-    }
-}
+const KING_LABELS: Record<TimeControl, string> = {
+    blitz: "👑 King of Blitz",
+    bullet: "🔫 Best Bullet Player",
+    rapid: "🏃 Rapid Champion"
+};
 
 function getPositionEmoji(position: number): string {
     switch (position) {
@@ -216,4 +25,104 @@ function getPositionEmoji(position: number): string {
         case 3: return "🥉";
         default: return `${position}.`;
     }
+}
+
+function sortByScore(players: DetailedPlayerStats[], score: (p: DetailedPlayerStats) => number): DetailedPlayerStats[] {
+    return [...players].sort((a, b) => {
+        if (score(b) !== score(a)) return score(b) - score(a);
+        if (b.winRate !== a.winRate) return b.winRate - a.winRate;
+        return b.wins - a.wins;
+    });
+}
+
+// viewer/isPrivate: "(you: X)" suffixes are shown only in private chats
+export async function renderTop(option: TopOption, viewer?: string | null, isPrivate = false): Promise<string> {
+    const userMap = await getAllUserMappings();
+
+    if (Object.keys(userMap).length === 0) {
+        return "⚠️ No registered users found. Users can register with /start";
+    }
+
+    const now = new Date();
+    let startDate: Date;
+
+    if (option === 'bugun') {
+        startDate = getStartOfDayTajikistan(now);
+    } else {
+        const tajikTime = getTajikistanTime(now);
+        startDate = new Date(Date.UTC(
+            tajikTime.getFullYear(),
+            tajikTime.getMonth(),
+            1,
+            -5, // 00:00 Tajikistan time in UTC
+            0, 0, 0
+        ));
+    }
+
+    const playerStats = await collectDetailedStats(userMap, startDate, now);
+    const allPlayers = [...playerStats.values()];
+    const showYou = isPrivate && viewer && playerStats.has(viewer);
+    const viewerStats = viewer ? playerStats.get(viewer) : undefined;
+
+    // Main leaderboard: overall for bugun/month, per-control for blitz/bullet/rapid
+    const isTCView = option === 'blitz' || option === 'bullet' || option === 'rapid';
+    const boardScore = isTCView
+        ? (p: DetailedPlayerStats) => p.perTC[option as TimeControl].weightedScore
+        : (p: DetailedPlayerStats) => p.weightedScore;
+    const boardGames = isTCView
+        ? (p: DetailedPlayerStats) => p.perTC[option as TimeControl].games
+        : (p: DetailedPlayerStats) => p.totalGames;
+
+    const sortedPlayers = sortByScore(allPlayers, boardScore).filter(p => boardGames(p) >= 3);
+
+    const lines: string[] = [TITLES[option], ""];
+
+    if (sortedPlayers.length === 0) {
+        lines.push("📊 No qualifying players found.");
+        lines.push("Players need at least 3 games to appear on the leaderboard.");
+    } else {
+        let currentRank = 1;
+        for (let i = 0; i < sortedPlayers.length; i++) {
+            const player = sortedPlayers[i];
+            if (i > 0 && Math.abs(boardScore(player) - boardScore(sortedPlayers[i - 1])) >= 0.01) {
+                currentRank++;
+            }
+            lines.push(`${getPositionEmoji(currentRank)} ${player.username}: ${boardScore(player).toFixed(1)}`);
+        }
+    }
+
+    // Kings of each time control + best win streak — today's view only
+    if (option === 'bugun') {
+        lines.push("");
+        for (const tc of ['blitz', 'bullet', 'rapid'] as TimeControl[]) {
+            const contenders = sortByScore(allPlayers.filter(p => p.perTC[tc].games > 0), p => p.perTC[tc].weightedScore);
+            const king = contenders[0];
+            let line = `${KING_LABELS[tc]}: `;
+            if (king) {
+                line += `@${king.username} — ${Math.round(king.perTC[tc].weightedScore)}`;
+                if (showYou && viewerStats && king.username !== viewer) {
+                    line += ` (you: ${Math.round(viewerStats.perTC[tc].weightedScore)})`;
+                }
+            } else {
+                line += "no games yet";
+            }
+            lines.push(line);
+        }
+
+        const streakLeader = allPlayers
+            .filter(p => p.bestStreak > 0)
+            .sort((a, b) => b.bestStreak - a.bestStreak)[0];
+        let streakLine = "🔥 Best Win Streak (today): ";
+        if (streakLeader) {
+            streakLine += `@${streakLeader.username} — ${streakLeader.bestStreak}`;
+            if (showYou && viewerStats && streakLeader.username !== viewer) {
+                streakLine += ` (you: ${viewerStats.bestStreak})`;
+            }
+        } else {
+            streakLine += "no wins yet";
+        }
+        lines.push(streakLine);
+    }
+
+    return lines.join('\n');
 }

--- a/test-daily-stats.ts
+++ b/test-daily-stats.ts
@@ -1,0 +1,72 @@
+// Temporary smoke test for utils/dailyStats.ts (run: npx ts-node test-daily-stats.ts)
+import { collectDetailedStats } from './utils/dailyStats';
+
+const now = Date.now();
+const hoursAgo = (h: number) => now - h * 60 * 60 * 1000;
+
+// Chess.com: win(blitz), win(blitz), draw(rapid), win(blitz), loss(rapid) -> blitz 3-0, rapid 0-1, streak max 2
+const chessComGames = [
+  { end_time: Math.floor(hoursAgo(10) / 1000), time_class: 'blitz', white: { username: 'alice_cc', result: 'win' }, black: { username: 'opp', result: 'checkmated' } },
+  { end_time: Math.floor(hoursAgo(9) / 1000), time_class: 'blitz', white: { username: 'opp', result: 'resigned' }, black: { username: 'alice_cc', result: 'win' } },
+  { end_time: Math.floor(hoursAgo(8) / 1000), time_class: 'rapid', white: { username: 'alice_cc', result: 'agreed' }, black: { username: 'opp', result: 'agreed' } },
+  { end_time: Math.floor(hoursAgo(7) / 1000), time_class: 'blitz', white: { username: 'alice_cc', result: 'win' }, black: { username: 'opp', result: 'timeout' } },
+  { end_time: Math.floor(hoursAgo(6) / 1000), time_class: 'rapid', white: { username: 'opp', result: 'win' }, black: { username: 'alice_cc', result: 'checkmated' } },
+];
+
+// Lichess: 4 consecutive bullet wins -> streak 4 (should beat chess.com's 2)
+const lichessGames = Array.from({ length: 4 }, (_, i) => ({
+  id: `g${i}`,
+  rated: true,
+  speed: 'bullet',
+  createdAt: hoursAgo(5 - i),
+  lastMoveAt: hoursAgo(5 - i),
+  status: 'mate',
+  players: { white: { user: { name: 'alice_li' } }, black: { user: { name: 'opp' } } },
+  winner: 'white'
+}));
+
+const realFetch = globalThis.fetch;
+(globalThis as any).fetch = async (url: string) => {
+  const u = String(url);
+  if (u.includes('/games/archives')) {
+    return { ok: true, json: async () => ({ archives: ['https://api.chess.com/pub/player/alice_cc/games/2026/07'] }) };
+  }
+  if (u.includes('/games/2026/07')) {
+    return { ok: true, json: async () => ({ games: chessComGames }) };
+  }
+  if (u.includes('lichess.org/api/games')) {
+    return { ok: true, text: async () => lichessGames.map(g => JSON.stringify(g)).join('\n') };
+  }
+  return realFetch(url as any);
+};
+
+async function main() {
+  const userMap = { alice: { chess: 'alice_cc', lichess: 'alice_li' } };
+  const stats = await collectDetailedStats(userMap as any, new Date(hoursAgo(12)), new Date(now));
+  const alice = stats.get('alice')!;
+
+  const checks: [string, boolean][] = [
+    ['overall wins = 7', alice.wins === 7],
+    ['overall losses = 1', alice.losses === 1],
+    ['totalGames = 8 (draw excluded)', alice.totalGames === 8],
+    ['blitz: 3 wins 0 losses', alice.perTC.blitz.wins === 3 && alice.perTC.blitz.losses === 0],
+    ['bullet: 4 wins', alice.perTC.bullet.wins === 4],
+    ['rapid: 0 wins 1 loss', alice.perTC.rapid.wins === 0 && alice.perTC.rapid.losses === 1],
+    ['bestStreak = 4 (lichess beats chess.com 2, draw resets)', alice.bestStreak === 4],
+    ['blitz weighted = 100*sqrt(3) ~ 173', Math.abs(alice.perTC.blitz.weightedScore - 100 * Math.sqrt(3)) < 0.01],
+    ['overall weighted > 0 (>=3 games)', alice.weightedScore > 0],
+  ];
+
+  let failed = 0;
+  for (const [name, ok] of checks) {
+    console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}`);
+    if (!ok) failed++;
+  }
+  if (failed) {
+    console.log(JSON.stringify(alice, null, 2));
+    process.exit(1);
+  }
+  console.log('All checks passed');
+}
+
+main();

--- a/utils/dailyStats.ts
+++ b/utils/dailyStats.ts
@@ -1,0 +1,206 @@
+// Detailed stats collector for /top views.
+// Single pass over each player's games producing: overall leaderboard stats,
+// per-time-control breakdowns (blitz/bullet/rapid kings) and win streaks.
+import { fetchLichessGames } from './chessApis';
+
+export type TimeControl = 'blitz' | 'bullet' | 'rapid';
+export type GameResult = 'win' | 'loss' | 'draw';
+
+export interface TCStats {
+  wins: number;
+  losses: number;
+  games: number;         // wins + losses (draws excluded, same as overall stats)
+  winRate: number;       // percent
+  weightedScore: number; // (winRate/100) * sqrt(games) * 100
+}
+
+export interface DetailedPlayerStats {
+  username: string;
+  wins: number;
+  losses: number;
+  totalGames: number;
+  winRate: number;
+  weightedScore: number; // 0 unless totalGames >= 3 (main leaderboard rule)
+  perTC: Record<TimeControl, TCStats>;
+  bestStreak: number;    // longest consecutive-win run in period, max across platforms; draws reset it
+}
+
+const WEIGHT_FACTOR = 100;
+
+function emptyTC(): TCStats {
+  return { wins: 0, losses: 0, games: 0, winRate: 0, weightedScore: 0 };
+}
+
+function emptyStats(username: string): DetailedPlayerStats {
+  return {
+    username,
+    wins: 0,
+    losses: 0,
+    totalGames: 0,
+    winRate: 0,
+    weightedScore: 0,
+    perTC: { blitz: emptyTC(), bullet: emptyTC(), rapid: emptyTC() },
+    bestStreak: 0
+  };
+}
+
+// Mirror of processGame() in gameStats.ts, but distinguishes draws (needed for streaks)
+export function getGameResult(game: any, username: string, platform: 'chess.com' | 'lichess'): GameResult {
+  if (platform === 'chess.com') {
+    const isWhite = game.white.username.toLowerCase() === username.toLowerCase();
+    const playerResult = isWhite ? game.white.result : game.black.result;
+    const opponentResult = isWhite ? game.black.result : game.white.result;
+
+    if (playerResult === 'win' || opponentResult === 'resigned' ||
+        opponentResult === 'timeout' || opponentResult === 'abandoned') {
+      return 'win';
+    }
+    if (opponentResult === 'win' || playerResult === 'resigned' ||
+        playerResult === 'timeout' || playerResult === 'abandoned') {
+      return 'loss';
+    }
+    return 'draw';
+  }
+
+  // Lichess
+  const whitePlayer = game.players.white.user?.name?.toLowerCase();
+  const isWhite = whitePlayer === username.toLowerCase();
+  const winner = game.winner;
+
+  if (!winner) return 'draw';
+  return (isWhite && winner === 'white') || (!isWhite && winner === 'black') ? 'win' : 'loss';
+}
+
+function timeControlOf(game: any, platform: 'chess.com' | 'lichess'): TimeControl | null {
+  const value = platform === 'chess.com' ? game.time_class : game.speed;
+  if (value === 'blitz' || value === 'rapid' || value === 'bullet') return value;
+  if (value === 'ultraBullet') return 'bullet';
+  return null; // daily / classical / correspondence — count toward overall only
+}
+
+interface TimedResult {
+  time: number;
+  result: GameResult;
+  tc: TimeControl | null;
+}
+
+async function fetchChessComResults(chessUsername: string, startMs: number, endMs: number): Promise<TimedResult[]> {
+  const results: TimedResult[] = [];
+  try {
+    const archivesRes = await fetch(`https://api.chess.com/pub/player/${chessUsername}/games/archives`);
+    if (!archivesRes.ok) return results;
+    const archives = await archivesRes.json();
+    if (!archives.archives?.length) return results;
+
+    const currentMonth = archives.archives[archives.archives.length - 1];
+    const gamesRes = await fetch(currentMonth);
+    if (!gamesRes.ok) return results;
+
+    const data = await gamesRes.json();
+    for (const game of data.games || []) {
+      const time = game.end_time * 1000;
+      if (time < startMs || time > endMs) continue;
+      results.push({
+        time,
+        result: getGameResult(game, chessUsername, 'chess.com'),
+        tc: timeControlOf(game, 'chess.com')
+      });
+    }
+  } catch (error) {
+    console.error(`Error fetching Chess.com games for ${chessUsername}:`, error);
+  }
+  return results;
+}
+
+async function fetchLichessResults(lichessUsername: string, startMs: number, endMs: number): Promise<TimedResult[]> {
+  const results: TimedResult[] = [];
+  try {
+    const games = await fetchLichessGames(lichessUsername, startMs, endMs);
+    if (!games) return results;
+
+    for (const game of games) {
+      const time = game.lastMoveAt || game.createdAt;
+      if (time < startMs || time > endMs) continue;
+      results.push({
+        time,
+        result: getGameResult(game, lichessUsername, 'lichess'),
+        tc: timeControlOf(game, 'lichess')
+      });
+    }
+  } catch (error) {
+    console.error(`Error fetching Lichess games for ${lichessUsername}:`, error);
+  }
+  return results;
+}
+
+// Longest run of consecutive wins; losses AND draws reset the streak
+function maxWinStreak(results: TimedResult[]): number {
+  const sorted = [...results].sort((a, b) => a.time - b.time);
+  let best = 0;
+  let current = 0;
+  for (const r of sorted) {
+    if (r.result === 'win') {
+      current++;
+      if (current > best) best = current;
+    } else {
+      current = 0;
+    }
+  }
+  return best;
+}
+
+function applyResults(stats: DetailedPlayerStats, results: TimedResult[]) {
+  for (const r of results) {
+    if (r.result === 'draw') continue; // draws excluded from win/loss stats (existing behavior)
+    const buckets: { wins: number; losses: number }[] = [stats];
+    if (r.tc) buckets.push(stats.perTC[r.tc]);
+    for (const b of buckets) {
+      if (r.result === 'win') b.wins++;
+      else b.losses++;
+    }
+  }
+
+  stats.totalGames = stats.wins + stats.losses;
+  stats.winRate = stats.totalGames > 0 ? (stats.wins / stats.totalGames) * 100 : 0;
+  stats.weightedScore = stats.totalGames >= 3
+    ? (stats.winRate / 100) * Math.sqrt(stats.totalGames) * WEIGHT_FACTOR
+    : 0;
+
+  for (const tc of ['blitz', 'bullet', 'rapid'] as TimeControl[]) {
+    const s = stats.perTC[tc];
+    s.games = s.wins + s.losses;
+    s.winRate = s.games > 0 ? (s.wins / s.games) * 100 : 0;
+    // Kings need only 1+ game in the control, so no 3-game floor here
+    s.weightedScore = s.games > 0 ? (s.winRate / 100) * Math.sqrt(s.games) * WEIGHT_FACTOR : 0;
+  }
+}
+
+export async function collectDetailedStats(
+  userMap: Record<string, { chess: string | null; lichess: string | null }>,
+  startDate: Date,
+  endDate: Date
+): Promise<Map<string, DetailedPlayerStats>> {
+  const startMs = startDate.getTime();
+  const endMs = endDate.getTime();
+  const playerStats = new Map<string, DetailedPlayerStats>();
+
+  await Promise.all(Object.entries(userMap).map(async ([tgUsername, mappings]) => {
+    const stats = emptyStats(tgUsername);
+    playerStats.set(tgUsername, stats);
+
+    try {
+      const [chesscomResults, lichessResults] = await Promise.all([
+        mappings.chess ? fetchChessComResults(mappings.chess, startMs, endMs) : Promise.resolve([]),
+        mappings.lichess ? fetchLichessResults(mappings.lichess, startMs, endMs) : Promise.resolve([])
+      ]);
+
+      applyResults(stats, [...chesscomResults, ...lichessResults]);
+      // Streaks are per platform; the displayed value is the best of the two
+      stats.bestStreak = Math.max(maxWinStreak(chesscomResults), maxWinStreak(lichessResults));
+    } catch (error) {
+      console.error(`Error collecting stats for ${tgUsername}:`, error);
+    }
+  }));
+
+  return playerStats;
+}

--- a/utils/headToHead.ts
+++ b/utils/headToHead.ts
@@ -1,0 +1,137 @@
+// Head-to-head comparison between two registered players (extracted from the old /score command
+// so it can be driven by inline buttons)
+import { getUserMappings } from "./userMap";
+import { fetchLichessGames } from "./chessApis";
+
+export async function renderHeadToHead(tgUser1: string, tgUser2: string): Promise<string> {
+    const userMappingsArray = await Promise.all([getUserMappings(tgUser1), getUserMappings(tgUser2)]);
+
+    if (userMappingsArray.some(mapping => !mapping || (!mapping.chess && !mapping.lichess))) {
+        return "⚠️ One or both users haven't registered any chess platform usernames. They should use /start first.";
+    }
+
+    const [user1Mappings, user2Mappings] = userMappingsArray as Array<{ chess: string | null; lichess: string | null }>;
+
+    // Prioritize Chess.com for head-to-head comparison, fall back to Lichess
+    const player1 = user1Mappings.chess || user1Mappings.lichess;
+    const player2 = user2Mappings.chess || user2Mappings.lichess;
+
+    if (!player1 || !player2) {
+        return "⚠️ Unable to determine chess usernames for comparison.";
+    }
+
+    const platform = (user1Mappings.chess && user2Mappings.chess) ? 'chess.com' : 'lichess';
+
+    try {
+        let headToHeadGames: any[] = [];
+
+        if (platform === 'chess.com') {
+            const archivesRes = await fetch(`https://api.chess.com/pub/player/${player1}/games/archives`);
+            if (!archivesRes.ok) {
+                return "⚠️ Error fetching game archives. Please try again later.";
+            }
+
+            const archives = await archivesRes.json();
+            const currentMonth = archives.archives[archives.archives.length - 1];
+
+            const gamesRes = await fetch(currentMonth);
+            if (!gamesRes.ok) {
+                return "⚠️ Error fetching games. Please try again later.";
+            }
+
+            const { games } = await gamesRes.json();
+
+            headToHeadGames = games.filter((game: any) =>
+                (game.white.username.toLowerCase() === player1.toLowerCase() && game.black.username.toLowerCase() === player2.toLowerCase()) ||
+                (game.white.username.toLowerCase() === player2.toLowerCase() && game.black.username.toLowerCase() === player1.toLowerCase())
+            );
+        } else {
+            const now = Date.now();
+            const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
+
+            const games1 = await fetchLichessGames(player1, oneMonthAgo, now);
+            const games2 = await fetchLichessGames(player2, oneMonthAgo, now);
+
+            if (!games1 || !games2) {
+                return "⚠️ Error fetching games from Lichess. Please try again later.";
+            }
+
+            const allGames = [...games1, ...games2];
+            const gameIds = new Set();
+
+            headToHeadGames = allGames.filter(game => {
+                const whiteName = game.players.white.user?.name?.toLowerCase();
+                const blackName = game.players.black.user?.name?.toLowerCase();
+                const isHeadToHead = (
+                    (whiteName === player1.toLowerCase() && blackName === player2.toLowerCase()) ||
+                    (whiteName === player2.toLowerCase() && blackName === player1.toLowerCase())
+                );
+
+                if (isHeadToHead && !gameIds.has(game.id)) {
+                    gameIds.add(game.id);
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        if (headToHeadGames.length === 0) {
+            return `📊 No games found between @${tgUser1} and @${tgUser2} for this month on ${platform}.`;
+        }
+
+        let player1Wins = 0;
+        let player2Wins = 0;
+        let draws = 0;
+
+        if (platform === 'chess.com') {
+            headToHeadGames.forEach((game: any) => {
+                const isPlayer1White = game.white.username.toLowerCase() === player1.toLowerCase();
+                const player1Result = isPlayer1White ? game.white.result : game.black.result;
+                const player2Result = isPlayer1White ? game.black.result : game.white.result;
+
+                if (player1Result === 'win' || player2Result === 'resigned' ||
+                    player2Result === 'timeout' || player2Result === 'abandoned') {
+                    player1Wins++;
+                } else if (player2Result === 'win' || player1Result === 'resigned' ||
+                    player1Result === 'timeout' || player1Result === 'abandoned') {
+                    player2Wins++;
+                } else {
+                    draws++;
+                }
+            });
+        } else {
+            headToHeadGames.forEach((game: any) => {
+                const whitePlayer = game.players.white.user?.name?.toLowerCase();
+                const winner = game.winner;
+
+                if (!winner) {
+                    draws++;
+                } else if ((whitePlayer === player1.toLowerCase() && winner === 'white') ||
+                          (whitePlayer !== player1.toLowerCase() && winner === 'black')) {
+                    player1Wins++;
+                } else {
+                    player2Wins++;
+                }
+            });
+        }
+
+        const lastGameUrl = platform === 'chess.com'
+            ? headToHeadGames[headToHeadGames.length - 1].url
+            : `https://lichess.org/${headToHeadGames[headToHeadGames.length - 1].id}`;
+
+        return [
+            `📊 Head-to-head stats for this month (${platform}):`,
+            `@${tgUser1} vs @${tgUser2}`,
+            ``,
+            `Total games: ${headToHeadGames.length}`,
+            `@${tgUser1} wins: ${player1Wins}`,
+            `@${tgUser2} wins: ${player2Wins}`,
+            `Draws: ${draws}`,
+            ``,
+            `Last game: ${lastGameUrl}`
+        ].join('\n');
+    } catch (err) {
+        console.error(err);
+        return "🚨 Error fetching head-to-head stats. Please try again later.";
+    }
+}

--- a/utils/keyboards.ts
+++ b/utils/keyboards.ts
@@ -1,0 +1,50 @@
+// Inline keyboards for the button-driven UI. No local imports here on purpose —
+// this module is shared by registration, start and the callback router.
+import { InlineKeyboard } from "grammy";
+
+export function mainMenu(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("🏆 Today's Top", "top:bugun").row()
+    .text("⚡ Blitz", "top:blitz")
+    .text("🔫 Bullet", "top:bullet")
+    .text("🏃 Rapid", "top:rapid").row()
+    .text("🏅 Standings", "st:all")
+    .text("👑 Champions", "st:recent").row()
+    .text("📊 My Stats", "stats:me")
+    .text("⚔️ Compare", "cmp").row()
+    .text("📈 Ratings", "ratings");
+}
+
+export function backToMenu(): InlineKeyboard {
+  return new InlineKeyboard().text("⬅️ Menu", "menu");
+}
+
+export function ratingsMenu(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("Chess.com ⚡", "rt:chesscom:blitz")
+    .text("Chess.com 🏃", "rt:chesscom:rapid")
+    .text("Chess.com 🔫", "rt:chesscom:bullet").row()
+    .text("Lichess ⚡", "rt:lichess:blitz")
+    .text("Lichess 🏃", "rt:lichess:rapid")
+    .text("Lichess 🔫", "rt:lichess:bullet").row()
+    .text("⬅️ Menu", "menu");
+}
+
+// Registration flow keyboards (callbacks are routed to the text-based registration handlers)
+export function platformSelectKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("1️⃣ Chess.com", "reg:1")
+    .text("2️⃣ Lichess", "reg:2").row()
+    .text("❌ Cancel / Бекор", "reg:no");
+}
+
+export function yesNoKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("✅ Yes / Ҳа", "reg:yes")
+    .text("❌ No / Не", "reg:no");
+}
+
+export const MENU_TEXT =
+  "♟️ Magnus Bot Menu\n" +
+  "Менюи Magnus Bot\n\n" +
+  "Интихоб кунед / Choose an option:";

--- a/utils/menu.ts
+++ b/utils/menu.ts
@@ -1,0 +1,160 @@
+// Callback router for the button-driven UI. All bot features are reachable from here.
+import { Context } from "grammy";
+import { renderTop, TopOption } from "../commands/top";
+import { renderStandings, renderRecentChampions } from "../commands/standings";
+import { renderStatsFor } from "../commands/stats";
+import { renderRatingsTable, RatingPlatform, RatingTC } from "./ratings";
+import { renderHeadToHead } from "./headToHead";
+import { getAllUserMappings } from "./userMap";
+import { handleRegistrationInput } from "./registration";
+import { mainMenu, backToMenu, ratingsMenu, MENU_TEXT } from "./keyboards";
+import { InlineKeyboard } from "grammy";
+
+// Replace the menu message content in place; fall back to a new message if editing fails
+async function show(ctx: Context, text: string, keyboard: InlineKeyboard = backToMenu()): Promise<void> {
+  try {
+    await ctx.editMessageText(text, { reply_markup: keyboard });
+  } catch {
+    await ctx.reply(text, { reply_markup: keyboard });
+  }
+}
+
+async function showLoading(ctx: Context): Promise<void> {
+  try {
+    await ctx.editMessageText("⏳ Loading... / Боркунӣ...");
+  } catch {
+    // Non-fatal: the final show() will still update or resend
+  }
+}
+
+function compareUserKeyboard(usernames: string[], firstIndex?: number): InlineKeyboard {
+  const kb = new InlineKeyboard();
+  let buttonsInRow = 0;
+  usernames.forEach((name, i) => {
+    if (firstIndex !== undefined && i === firstIndex) return;
+    const callback = firstIndex === undefined ? `cmp1:${i}` : `cmp2:${firstIndex}:${i}`;
+    kb.text(`@${name}`, callback);
+    buttonsInRow++;
+    if (buttonsInRow === 2) {
+      kb.row();
+      buttonsInRow = 0;
+    }
+  });
+  if (buttonsInRow > 0) kb.row();
+  kb.text("⬅️ Menu", "menu");
+  return kb;
+}
+
+async function sortedRegisteredUsers(): Promise<string[]> {
+  const userMap = await getAllUserMappings();
+  return Object.keys(userMap).sort((a, b) => a.localeCompare(b));
+}
+
+export async function handleMenuCallback(ctx: Context): Promise<void> {
+  const data = ctx.callbackQuery?.data;
+  if (!data) return;
+
+  // Acknowledge the tap immediately so the client stops the spinner
+  await ctx.answerCallbackQuery().catch(() => {});
+
+  try {
+    // Registration flow buttons (reg:1, reg:2, reg:yes, reg:no)
+    if (data.startsWith("reg:")) {
+      await handleRegistrationInput(ctx, data.slice(4));
+      return;
+    }
+
+    if (data === "menu") {
+      await show(ctx, MENU_TEXT, mainMenu());
+      return;
+    }
+
+    if (data.startsWith("top:")) {
+      const option = data.slice(4) as TopOption;
+      await showLoading(ctx);
+      const isPrivate = ctx.chat?.type === "private";
+      const text = await renderTop(option, ctx.from?.username ?? null, isPrivate);
+      await show(ctx, text);
+      return;
+    }
+
+    if (data === "st:all") {
+      await showLoading(ctx);
+      await show(ctx, await renderStandings());
+      return;
+    }
+
+    if (data === "st:recent") {
+      await showLoading(ctx);
+      await show(ctx, await renderRecentChampions());
+      return;
+    }
+
+    if (data === "stats:me") {
+      const username = ctx.from?.username;
+      if (!username) {
+        await show(ctx, "❌ You need to set a Telegram username to use this feature.");
+        return;
+      }
+      await showLoading(ctx);
+      await show(ctx, await renderStatsFor(username));
+      return;
+    }
+
+    if (data === "ratings") {
+      await show(ctx, "📈 Ratings / Рейтингҳо\n\nИнтихоб кунед / Choose platform and time control:", ratingsMenu());
+      return;
+    }
+
+    if (data.startsWith("rt:")) {
+      const [, platform, tc] = data.split(":");
+      await showLoading(ctx);
+      const text = await renderRatingsTable(platform as RatingPlatform, tc as RatingTC);
+      await show(ctx, text, ratingsMenu());
+      return;
+    }
+
+    if (data === "cmp") {
+      const users = await sortedRegisteredUsers();
+      if (users.length < 2) {
+        await show(ctx, "⚠️ Need at least 2 registered users to compare.");
+        return;
+      }
+      await show(ctx, "⚔️ Compare players\n\nSelect the FIRST player:", compareUserKeyboard(users));
+      return;
+    }
+
+    if (data.startsWith("cmp1:")) {
+      const firstIndex = parseInt(data.slice(5), 10);
+      const users = await sortedRegisteredUsers();
+      if (isNaN(firstIndex) || !users[firstIndex]) {
+        await show(ctx, "⚠️ Player list changed, please try again.", mainMenu());
+        return;
+      }
+      await show(
+        ctx,
+        `⚔️ Compare players\n\nFirst: @${users[firstIndex]}\nSelect the SECOND player:`,
+        compareUserKeyboard(users, firstIndex)
+      );
+      return;
+    }
+
+    if (data.startsWith("cmp2:")) {
+      const [i, j] = data.slice(5).split(":").map(n => parseInt(n, 10));
+      const users = await sortedRegisteredUsers();
+      if (isNaN(i) || isNaN(j) || !users[i] || !users[j]) {
+        await show(ctx, "⚠️ Player list changed, please try again.", mainMenu());
+        return;
+      }
+      await showLoading(ctx);
+      await show(ctx, await renderHeadToHead(users[i], users[j]));
+      return;
+    }
+
+    // Unknown callback: show the menu as a safe default
+    await show(ctx, MENU_TEXT, mainMenu());
+  } catch (error) {
+    console.error("Error handling menu callback:", error);
+    await show(ctx, "🚨 Something went wrong. Please try again.", mainMenu());
+  }
+}

--- a/utils/ratings.ts
+++ b/utils/ratings.ts
@@ -1,0 +1,74 @@
+// Live rating leaderboards per platform and time control (for the Ratings menu buttons)
+import { getAllUserMappings } from './userMap';
+import { fetchChessComStats, fetchLichessStats } from './chessApis';
+
+export type RatingPlatform = 'chesscom' | 'lichess';
+export type RatingTC = 'blitz' | 'rapid' | 'bullet';
+
+const PLATFORM_LABELS: Record<RatingPlatform, string> = {
+  chesscom: 'Chess.com',
+  lichess: 'Lichess'
+};
+
+const TC_LABELS: Record<RatingTC, string> = {
+  blitz: '⚡ Blitz',
+  rapid: '🏃 Rapid',
+  bullet: '🔫 Bullet'
+};
+
+function getPositionEmoji(position: number): string {
+  switch (position) {
+    case 1: return "🥇";
+    case 2: return "🥈";
+    case 3: return "🥉";
+    default: return `${position}.`;
+  }
+}
+
+export async function renderRatingsTable(platform: RatingPlatform, tc: RatingTC): Promise<string> {
+  const userMap = await getAllUserMappings();
+
+  const entries = Object.entries(userMap)
+    .map(([tgUsername, mappings]) => ({
+      tgUsername,
+      platformUsername: platform === 'chesscom' ? mappings.chess : mappings.lichess
+    }))
+    .filter(e => e.platformUsername);
+
+  if (entries.length === 0) {
+    return `📈 ${PLATFORM_LABELS[platform]} ${TC_LABELS[tc]}\n\nNo registered ${PLATFORM_LABELS[platform]} accounts yet.`;
+  }
+
+  const ratings = await Promise.all(entries.map(async e => {
+    let rating: number | null = null;
+    try {
+      if (platform === 'chesscom') {
+        const stats = await fetchChessComStats(e.platformUsername!);
+        const key = `chess_${tc}` as 'chess_blitz' | 'chess_rapid' | 'chess_bullet';
+        rating = stats?.[key]?.last?.rating ?? null;
+      } else {
+        const stats = await fetchLichessStats(e.platformUsername!);
+        rating = stats?.perfs?.[tc]?.rating ?? null;
+      }
+    } catch (error) {
+      console.error(`Error fetching ${platform} rating for ${e.tgUsername}:`, error);
+    }
+    return { tgUsername: e.tgUsername, rating };
+  }));
+
+  const ranked = ratings
+    .filter((r): r is { tgUsername: string; rating: number } => r.rating !== null)
+    .sort((a, b) => b.rating - a.rating);
+
+  const lines = [`📈 ${PLATFORM_LABELS[platform]} ${TC_LABELS[tc]} Ratings`, ""];
+
+  if (ranked.length === 0) {
+    lines.push(`No ${tc} ratings found for registered players.`);
+  } else {
+    ranked.forEach((r, i) => {
+      lines.push(`${getPositionEmoji(i + 1)} ${r.tgUsername} — ${r.rating}`);
+    });
+  }
+
+  return lines.join('\n');
+}

--- a/utils/registration.ts
+++ b/utils/registration.ts
@@ -1,6 +1,7 @@
 import { Context } from "grammy";
 import { saveUserMapping } from "../utils/supabase";
 import { verifyChessComUser, verifyLichessUser } from "../utils/chessApis";
+import { mainMenu, platformSelectKeyboard, yesNoKeyboard } from "../utils/keyboards";
 
 // Store user states for registration flow
 const userStates = new Map<number, { 
@@ -10,14 +11,19 @@ const userStates = new Map<number, {
 }>();
 
 export async function handleRegistration(ctx: Context): Promise<void> {
-  const userId = ctx.from?.id;
-  if (!userId) return;
-
   const text = ctx.message?.text?.trim();
   if (!text) return;
 
+  await handleRegistrationInput(ctx, text);
+}
+
+// Shared entry point for both typed answers and inline-button callbacks (reg:* callback data)
+export async function handleRegistrationInput(ctx: Context, text: string): Promise<void> {
+  const userId = ctx.from?.id;
+  if (!userId) return;
+
   const userState = userStates.get(userId);
-  
+
   if (userState?.step === 'waiting_for_platform') {
     await handlePlatformSelection(ctx, text);
   } else if (userState?.step === 'waiting_for_chess_username') {
@@ -77,11 +83,9 @@ async function handlePlatformSelection(ctx: Context, selection: string): Promise
     );
   } else {
     await ctx.reply(
-      "❌ Интихоби нодуруст. Лутфан 1 ё 2-ро интихоб кунед:\n" +
-      "❌ Invalid choice. Please select 1 or 2:\n\n" +
-      "1️⃣ Chess.com\n" +
-      "2️⃣ Lichess\n\n" +
-      "Ё \"не/no\" барои бекор кардан / Or \"no\" to cancel"
+      "❌ Интихоби нодуруст. Лутфан интихоб кунед:\n" +
+      "❌ Invalid choice. Please select a platform:",
+      { reply_markup: platformSelectKeyboard() }
     );
   }
 }
@@ -127,24 +131,20 @@ async function handleChessUsernameInput(ctx: Context, chessUsername: string): Pr
     "✅ Муваффақият! Шумо сабт шудед! / Success! You are registered!\n\n" +
     `🎯 Telegram: @${telegramUsername}\n` +
     `♟️ Chess.com: ${chessUsername}\n` +
-    `${lichessUsername ? `♟️ Lichess: ${lichessUsername}\n` : ''}` +
-    "\nҲозир шумо метавонед:\n" +
-    "Now you can use:\n" +
-    "📊 /stats - Омори шахмат / View your chess statistics\n" +
-    "🏆 /top - Рейтинг / See leaderboards\n" +
-    "⚔️ /score @user1 @user2 - Муқоисаи бозигарон / Compare players"
+    `${lichessUsername ? `♟️ Lichess: ${lichessUsername}\n` : ''}`,
+    lichessUsername ? { reply_markup: mainMenu() } : undefined
   );
 
   // Ask if they want to add the other platform
   if (!lichessUsername) {
-    userStates.set(userId, { 
+    userStates.set(userId, {
       step: 'waiting_for_additional_platform',
-      chessUsername 
+      chessUsername
     });
     await ctx.reply(
       "➕ Оё шумо мехоҳед Lichess-ро низ илова кунед?\n" +
-      "➕ Would you like to also add Lichess?\n\n" +
-      "Ҷавоб диҳед: ҳа/бале/yes ё не/нест/no"
+      "➕ Would you like to also add Lichess?",
+      { reply_markup: yesNoKeyboard() }
     );
   }
 }
@@ -190,24 +190,20 @@ async function handleLichessUsernameInput(ctx: Context, lichessUsername: string)
     "✅ Муваффақият! Шумо сабт шудед! / Success! You are registered!\n\n" +
     `🎯 Telegram: @${telegramUsername}\n` +
     `${chessUsername ? `♟️ Chess.com: ${chessUsername}\n` : ''}` +
-    `♟️ Lichess: ${lichessUsername}\n\n` +
-    "Ҳозир шумо метавонед:\n" +
-    "Now you can use:\n" +
-    "📊 /stats - Омори шахмат / View your chess statistics\n" +
-    "🏆 /top - Рейтинг / See leaderboards\n" +
-    "⚔️ /score @user1 @user2 - Муқоисаи бозигарон / Compare players"
+    `♟️ Lichess: ${lichessUsername}`,
+    chessUsername ? { reply_markup: mainMenu() } : undefined
   );
 
   // Ask if they want to add the other platform
   if (!chessUsername) {
-    userStates.set(userId, { 
+    userStates.set(userId, {
       step: 'waiting_for_additional_platform',
-      lichessUsername 
+      lichessUsername
     });
     await ctx.reply(
       "➕ Оё шумо мехоҳед Chess.com-ро низ илова кунед?\n" +
-      "➕ Would you like to also add Chess.com?\n\n" +
-      "Ҷавоб диҳед: ҳа/бале/yes ё не/нест/no"
+      "➕ Would you like to also add Chess.com?",
+      { reply_markup: yesNoKeyboard() }
     );
   }
 }
@@ -249,12 +245,13 @@ async function handleAdditionalPlatformSelection(ctx: Context, response: string)
     userStates.delete(userId);
     await ctx.reply(
       "✅ Хуб! Шумо ҳар вақт метавонед платформаи дигарро бо /start илова кунед.\n" +
-      "✅ Great! You can always add the other platform later with /start."
+      "✅ Great! You can always add the other platform later with /start.",
+      { reply_markup: mainMenu() }
     );
   } else {
     await ctx.reply(
-      "❌ Лутфан ҳа/бале/yes ё не/нест/no ҷавоб диҳед:\n" +
-      "❌ Please answer yes or no:"
+      "❌ Лутфан интихоб кунед / Please answer:",
+      { reply_markup: yesNoKeyboard() }
     );
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,9 @@
   "functions": {
     "api/daily-championship.ts": {
       "maxDuration": 300
+    },
+    "api/webhook.ts": {
+      "maxDuration": 60
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- **/top (Today's Top)** now shows per-time-control daily leaders after the main leaderboard: King of Blitz, Best Bullet Player, Rapid Champion (weighted score per control, 1+ game to qualify), plus Best Win Streak of the day. "(you: X)" suffixes appear in private chats only.
- **Win streaks**: computed per platform chronologically (draws reset the streak), displayed value is the max of Chess.com and Lichess streaks.
- **Button-driven UI**: all commands except /start replaced with an inline keyboard menu — top boards, standings, recent champions, my stats, two-step player comparison, and live rating tables (Chess.com/Lichess x blitz/rapid/bullet).
- **Registration flow** now uses inline buttons for platform selection and yes/no prompts (usernames still typed).
- New one-pass stats collector `utils/dailyStats.ts`; also fixes a bug where monthly leaderboards only counted today's games (date equality instead of range filtering).
- `vercel.json`: webhook maxDuration set to 60s (rating tables fan out one API call per registered user).

## Not touched
- Daily championship cron (`api/daily-championship.ts`, `utils/gameStats.ts`, `utils/championship.ts`) runs on its existing code path — no risk to daily awards.
- No database schema changes — zero-downtime deploy.

## Testing
- `tsc --noEmit` passes.
- Synthetic smoke test `test-daily-stats.ts` (stubbed Chess.com/Lichess APIs): 9/9 checks pass — per-control buckets, draw-resets-streak, max-across-platforms, weighted score math.
- Live verification requires deploy (no local .env): after merge, tap through every menu button in a test chat, in both private and group contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)