### PR TITLE
feat: game invites — challenge a club member from the menu

### DIFF
--- a/utils/invite.ts
+++ b/utils/invite.ts
@@ -11,9 +11,13 @@ export interface InviteTimeControl {
 
 export const INVITE_TIME_CONTROLS: InviteTimeControl[] = [
   { label: "🔫 1+0", limit: 60, increment: 0 },
+  { label: "🔫 1+1", limit: 60, increment: 1 },
   { label: "⚡ 3+0", limit: 180, increment: 0 },
+  { label: "⚡ 3+2", limit: 180, increment: 2 },
   { label: "⚡ 5+0", limit: 300, increment: 0 },
-  { label: "🏃 10+0", limit: 600, increment: 0 }
+  { label: "⚡ 5+3", limit: 300, increment: 3 },
+  { label: "🏃 10+0", limit: 600, increment: 0 },
+  { label: "🏃 10+5", limit: 600, increment: 5 }
 ];
 
 async function createLichessOpenChallenge(

--- a/utils/invite.ts
+++ b/utils/invite.ts
@@ -1,0 +1,111 @@
+// Game invites: Lichess open challenge (created via API, restricted to the two players)
+// plus a prefilled Chess.com challenge link (Chess.com has no public challenge API).
+import { InlineKeyboard } from "grammy";
+import { getUserMappings } from "./userMap";
+
+export interface InviteTimeControl {
+  label: string;
+  limit: number;     // initial clock, seconds
+  increment: number; // seconds per move
+}
+
+export const INVITE_TIME_CONTROLS: InviteTimeControl[] = [
+  { label: "🔫 1+0", limit: 60, increment: 0 },
+  { label: "⚡ 3+0", limit: 180, increment: 0 },
+  { label: "⚡ 5+0", limit: 300, increment: 0 },
+  { label: "🏃 10+0", limit: 600, increment: 0 }
+];
+
+async function createLichessOpenChallenge(
+  tc: InviteTimeControl,
+  rated: boolean,
+  lichessUsers?: [string, string]
+): Promise<string | null> {
+  try {
+    const params = new URLSearchParams();
+    params.set("rated", String(rated));
+    params.set("clock.limit", String(tc.limit));
+    params.set("clock.increment", String(tc.increment));
+    // Restrict the open challenge so only these two accounts can join
+    if (lichessUsers) params.set("users", lichessUsers.join(","));
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/x-www-form-urlencoded"
+    };
+    if (process.env.LICHESS_API_TOKEN) {
+      headers["Authorization"] = `Bearer ${process.env.LICHESS_API_TOKEN}`;
+    }
+
+    const response = await fetch("https://lichess.org/api/challenge/open", {
+      method: "POST",
+      headers,
+      body: params.toString()
+    });
+
+    if (!response.ok) {
+      console.error(`Lichess open challenge failed: ${response.status} ${await response.text()}`);
+      return null;
+    }
+
+    const data = await response.json();
+    const id = data.challenge?.id ?? data.id;
+    return data.challenge?.url ?? data.url ?? (id ? `https://lichess.org/${id}` : null);
+  } catch (error) {
+    console.error("Error creating Lichess open challenge:", error);
+    return null;
+  }
+}
+
+export interface InviteMessage {
+  text: string;
+  keyboard: InlineKeyboard;
+}
+
+export async function buildInvite(
+  challengerTg: string,
+  opponentTg: string,
+  tcIndex: number,
+  rated: boolean
+): Promise<InviteMessage | null> {
+  const tc = INVITE_TIME_CONTROLS[tcIndex];
+  if (!tc) return null;
+
+  const [challenger, opponent] = await Promise.all([
+    getUserMappings(challengerTg),
+    getUserMappings(opponentTg)
+  ]);
+
+  const bothOnLichess = !!(challenger?.lichess && opponent?.lichess);
+  const lichessUrl = bothOnLichess
+    ? await createLichessOpenChallenge(tc, rated, [challenger!.lichess!, opponent!.lichess!])
+    : null;
+  const chesscomUrl = opponent?.chess
+    ? `https://www.chess.com/play/online/new?opponent=${encodeURIComponent(opponent.chess)}`
+    : null;
+
+  if (!lichessUrl && !chesscomUrl) {
+    return null;
+  }
+
+  const lines = [
+    "🎯 Даъват ба бозӣ! / Game Invite!",
+    "",
+    `@${challengerTg} ⚔️ @${opponentTg}`,
+    `${tc.label} • ${rated ? "⭐ Rated" : "🎲 Casual"}`,
+    ""
+  ];
+
+  if (lichessUrl) {
+    lines.push("♞ Lichess: ҳарду бозигар тугмаро пахш кунанд / both players tap the button to join");
+  }
+  if (chesscomUrl) {
+    lines.push(`♟ Chess.com: @${challengerTg} тугмаро пахш кунад / taps the button to send the challenge`);
+    lines.push("   (вақт ва навъи бозӣ дар Chess.com интихоб кунед / pick time and rated mode on Chess.com)");
+  }
+
+  const keyboard = new InlineKeyboard();
+  if (lichessUrl) keyboard.url("♞ Play on Lichess", lichessUrl).row();
+  if (chesscomUrl) keyboard.url("♟ Challenge on Chess.com", chesscomUrl).row();
+
+  return { text: lines.join("\n"), keyboard };
+}

--- a/utils/keyboards.ts
+++ b/utils/keyboards.ts
@@ -12,7 +12,8 @@ export function mainMenu(): InlineKeyboard {
     .text("👑 Champions", "st:recent").row()
     .text("📊 My Stats", "stats:me")
     .text("⚔️ Compare", "cmp").row()
-    .text("📈 Ratings", "ratings");
+    .text("📈 Ratings", "ratings")
+    .text("🎯 Send Invite", "inv");
 }
 
 export function backToMenu(): InlineKeyboard {

--- a/utils/menu.ts
+++ b/utils/menu.ts
@@ -193,8 +193,11 @@ export async function handleMenuCallback(ctx: Context): Promise<void> {
         return;
       }
       const kb = new InlineKeyboard();
-      INVITE_TIME_CONTROLS.forEach((tc, t) => kb.text(tc.label, `inv2:${opponentIndex}:${t}`));
-      kb.row().text("⬅️ Menu", "menu");
+      INVITE_TIME_CONTROLS.forEach((tc, t) => {
+        kb.text(tc.label, `inv2:${opponentIndex}:${t}`);
+        if ((t + 1) % 4 === 0) kb.row();
+      });
+      kb.text("⬅️ Menu", "menu");
       await show(
         ctx,
         `🎯 Invite for @${users[opponentIndex]}\n\nНазорати вақтро интихоб кунед / Select time control:`,

--- a/utils/menu.ts
+++ b/utils/menu.ts
@@ -5,6 +5,7 @@ import { renderStandings, renderRecentChampions } from "../commands/standings";
 import { renderStatsFor } from "../commands/stats";
 import { renderRatingsForTC, RatingTC } from "./ratings";
 import { renderHeadToHead } from "./headToHead";
+import { buildInvite, INVITE_TIME_CONTROLS } from "./invite";
 import { getAllUserMappings } from "./userMap";
 import { handleRegistrationInput } from "./registration";
 import { mainMenu, backToMenu, ratingsMenu, MENU_TEXT } from "./keyboards";
@@ -27,13 +28,17 @@ async function showLoading(ctx: Context): Promise<void> {
   }
 }
 
-function compareUserKeyboard(usernames: string[], firstIndex?: number): InlineKeyboard {
+// Two-column keyboard of registered users; callbacks carry the user's index in the sorted list
+function userSelectKeyboard(
+  usernames: string[],
+  toCallback: (index: number) => string,
+  excludeName?: string
+): InlineKeyboard {
   const kb = new InlineKeyboard();
   let buttonsInRow = 0;
   usernames.forEach((name, i) => {
-    if (firstIndex !== undefined && i === firstIndex) return;
-    const callback = firstIndex === undefined ? `cmp1:${i}` : `cmp2:${firstIndex}:${i}`;
-    kb.text(`@${name}`, callback);
+    if (excludeName !== undefined && name === excludeName) return;
+    kb.text(`@${name}`, toCallback(i));
     buttonsInRow++;
     if (buttonsInRow === 2) {
       kb.row();
@@ -43,6 +48,14 @@ function compareUserKeyboard(usernames: string[], firstIndex?: number): InlineKe
   if (buttonsInRow > 0) kb.row();
   kb.text("⬅️ Menu", "menu");
   return kb;
+}
+
+function compareUserKeyboard(usernames: string[], firstIndex?: number): InlineKeyboard {
+  return userSelectKeyboard(
+    usernames,
+    firstIndex === undefined ? (i) => `cmp1:${i}` : (i) => `cmp2:${firstIndex}:${i}`,
+    firstIndex === undefined ? undefined : usernames[firstIndex]
+  );
 }
 
 async function sortedRegisteredUsers(): Promise<string[]> {
@@ -148,6 +161,86 @@ export async function handleMenuCallback(ctx: Context): Promise<void> {
       }
       await showLoading(ctx);
       await show(ctx, await renderHeadToHead(users[i], users[j]));
+      return;
+    }
+
+    // Game invite flow: pick opponent -> pick time control -> rated/casual -> post invite
+    if (data === "inv") {
+      const challenger = ctx.from?.username;
+      if (!challenger) {
+        await show(ctx, "❌ You need a Telegram username to send invites.");
+        return;
+      }
+      const users = await sortedRegisteredUsers();
+      const opponents = users.filter(u => u !== challenger);
+      if (opponents.length === 0) {
+        await show(ctx, "⚠️ No other registered players to invite.");
+        return;
+      }
+      await show(
+        ctx,
+        "🎯 Даъват / Send invite\n\nҲарифро интихоб кунед / Select your opponent:",
+        userSelectKeyboard(users, (i) => `inv1:${i}`, challenger)
+      );
+      return;
+    }
+
+    if (data.startsWith("inv1:")) {
+      const opponentIndex = parseInt(data.slice(5), 10);
+      const users = await sortedRegisteredUsers();
+      if (isNaN(opponentIndex) || !users[opponentIndex]) {
+        await show(ctx, "⚠️ Player list changed, please try again.", mainMenu());
+        return;
+      }
+      const kb = new InlineKeyboard();
+      INVITE_TIME_CONTROLS.forEach((tc, t) => kb.text(tc.label, `inv2:${opponentIndex}:${t}`));
+      kb.row().text("⬅️ Menu", "menu");
+      await show(
+        ctx,
+        `🎯 Invite for @${users[opponentIndex]}\n\nНазорати вақтро интихоб кунед / Select time control:`,
+        kb
+      );
+      return;
+    }
+
+    if (data.startsWith("inv2:")) {
+      const [opponentIndex, tcIndex] = data.slice(5).split(":").map(n => parseInt(n, 10));
+      const users = await sortedRegisteredUsers();
+      const tc = INVITE_TIME_CONTROLS[tcIndex];
+      if (isNaN(opponentIndex) || !users[opponentIndex] || !tc) {
+        await show(ctx, "⚠️ Something changed, please try again.", mainMenu());
+        return;
+      }
+      const kb = new InlineKeyboard()
+        .text("⭐ Rated", `inv3:${opponentIndex}:${tcIndex}:1`)
+        .text("🎲 Casual", `inv3:${opponentIndex}:${tcIndex}:0`).row()
+        .text("⬅️ Menu", "menu");
+      await show(
+        ctx,
+        `🎯 Invite for @${users[opponentIndex]} (${tc.label})\n\nНавъи бозӣ / Game type:`,
+        kb
+      );
+      return;
+    }
+
+    if (data.startsWith("inv3:")) {
+      const [opponentIndex, tcIndex, ratedFlag] = data.slice(5).split(":").map(n => parseInt(n, 10));
+      const challenger = ctx.from?.username;
+      const users = await sortedRegisteredUsers();
+      if (!challenger || isNaN(opponentIndex) || !users[opponentIndex] || !INVITE_TIME_CONTROLS[tcIndex]) {
+        await show(ctx, "⚠️ Something changed, please try again.", mainMenu());
+        return;
+      }
+      await showLoading(ctx);
+      const invite = await buildInvite(challenger, users[opponentIndex], tcIndex, ratedFlag === 1);
+      if (!invite) {
+        await show(ctx, `⚠️ Could not create an invite for @${users[opponentIndex]} — no platform accounts found or Lichess is unavailable.`);
+        return;
+      }
+      // Post the invite as a NEW message so the opponent gets a mention notification,
+      // then restore the menu in the original message
+      await ctx.reply(invite.text, { reply_markup: invite.keyboard });
+      await show(ctx, MENU_TEXT, mainMenu());
       return;
     }
 


### PR DESCRIPTION
## Summary
New "🎯 Send Invite" button in the main menu. Flow: pick an opponent from registered players (challenger excluded from the list) -> pick time control (1+0 / 3+0 / 5+0 / 10+0) -> pick Rated or Casual -> the bot posts an invite message mentioning both players.

## How the links work
- **Lichess**: the bot creates an open challenge via `POST /api/challenge/open` (works with or without `LICHESS_API_TOKEN`), restricted via the `users` param so only the two players' Lichess accounts can join. Both players tap one button. Shown only when both players have Lichess accounts.
- **Chess.com**: there is no public challenge API, so the invite carries a prefilled challenge link (`/play/online/new?opponent=...`); the challenger taps it and confirms time/rated settings on Chess.com. Shown when the opponent has a Chess.com account.
- The invite is posted as a new message (not an edit) so the opponent gets a Telegram mention notification; the original message returns to the menu.

## Testing
- `tsc --noEmit` passes.
- Live-tested the Lichess open challenge endpoint: response parsed correctly (`url` top-level field), challenge created with requested clock and rated flag.
- After deploy: Menu -> Send Invite -> full flow in a group; verify the Lichess button joins the created game and the Chess.com button opens a prefilled challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)